### PR TITLE
Allow bot to access oponent team

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ Players/bot*
 
 # Ignore Custom Files
 ignore*
+
+# Ignore rope refactoring
+.ropeproject/

--- a/Player.py
+++ b/Player.py
@@ -1,3 +1,5 @@
+import inspect
+
 class Player:
     def __init__(self,file_path):
         assert file_path[-3:None] == ".py", "Player file must be a python file"
@@ -19,8 +21,14 @@ class Player:
         self.step_func = step_func
         self.namespace = namespace
 
-    def start(self,team):
-        return self.start_func(team)
+    def start(self,team,opponent_team):
+        signature = inspect.signature(self.start_func)
+        num_args = len(signature.parameters)
+        if num_args == 1:
+            return self.start_func(team)
+        else:
+            return self.start_func(team,opponent_team)
+
 
     def step(self,board):
         return self.step_func(board)

--- a/PlayerController.py
+++ b/PlayerController.py
@@ -21,7 +21,7 @@ class GameEndException(Exception):
 
 
 class PlayerController:
-    def __init__(self, master, row, column, team):
+    def __init__(self, master, row, column, team, opponent_team):
         frame = Frame(master)
         frame.grid(row=row, column=column, padx=20, pady=20)
 
@@ -38,6 +38,7 @@ class PlayerController:
         self.output.grid(row=3)
 
         self.team = team
+        self.opponent_team = opponent_team
 
         self.time_label = Label(frame, width=20, text=f"{self.team.get_time()} s")
         self.time_label.grid(row=0)
@@ -63,7 +64,7 @@ class PlayerController:
         else:
             self.selected_player = self.players[selected]
 
-        self.start(self.team)
+        self.start(self.team, self.opponent_team)
 
     def add_player(self, path):
         name = os.path.split(path)[1].replace(".py", "")
@@ -92,8 +93,8 @@ class PlayerController:
         self.write_to_output(output_buffer.getvalue())
         return out
 
-    def start(self, team):
-        return self.capture_output(self.selected_player.start, team)
+    def start(self, team, opponent_team):
+        return self.capture_output(self.selected_player.start, team, opponent_team)
 
     def step(self, board):
         return self.capture_output(self.selected_player.step, board)

--- a/Players/Dummy.py
+++ b/Players/Dummy.py
@@ -14,7 +14,6 @@ def step(board):
         for j in range(board.board_size()):
             if not board[i, j]:
                 if random() > 0.3:
-                    return f"ps#[{i},{j}]"
+                    return f"PS;({i},{j})"
                 else:
-                    return f"pw#[{i},{j}]"
-
+                    return f"PW;({i},{j})"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-- Der Gesamte Bot muss in einer Pythin file geschrieben werden
+- Der Gesamte Bot muss in einer Python file geschrieben werden
 - Der Name des Bots sollte mit __bot__ beginnen
 - Der Bot muss eine __start__ und eine __step__ funktion erhalten
 - Jede Form des State muss in __start__ initialisiert werden. Dies sorgt dafür, dass Bots mehfach hintereinander gegeneinander spielen können, ohne den kompletten Namespace neu laden zu müssen
@@ -6,7 +6,12 @@
 ```
 def start(team):
   ...
-  return None #can be implicid
+  return None #can be implicit
+```
+oder
+```
+def start(team, opponent_team):
+  ...
 ```
 - Die __step__ funktion besitzt folgenden Syntax:
 ```

--- a/main.py
+++ b/main.py
@@ -16,8 +16,8 @@ BOARD_SIZE = 5
 tw = Team(BOARD_SIZE)
 tb = Team(BOARD_SIZE)
 
-pw = PlayerController(root, 0, 0, tw)
-pb = PlayerController(root, 0, 2, tb)
+pw = PlayerController(root, 0, 0, tw, tb)
+pb = PlayerController(root, 0, 2, tb, tw)
 
 t = TakController(root, 0, 1, tw, tb, board_size=BOARD_SIZE)
 


### PR DESCRIPTION
The bot should be able to get information about its opponent (e.g. remaining stones/capstones in opponents bank).

_Note: A bot's start function can still take only one argument._